### PR TITLE
fix: fix default java version

### DIFF
--- a/install/crafty-controller-install.sh
+++ b/install/crafty-controller-install.sh
@@ -26,19 +26,14 @@ $STD apt-get install -y \
   software-properties-common
 msg_ok "Installed Dependencies"
 
-msg_info "Setting up TermurinJDK"
+msg_info "Setting up TemurinJDK"
 mkdir -p /etc/apt/keyrings
 wget -qO - https://packages.adoptium.net/artifactory/api/gpg/key/public | tee /etc/apt/keyrings/adoptium.asc
 echo "deb [signed-by=/etc/apt/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list
 $STD apt-get update
-$STD apt-get install -y \
-  temurin-8-jre \
-  temurin-11-jre \
-  temurin-17-jre \
-  temurin-21-jre \
-  temurin-23-jre
+$STD apt-get install -y temurin-{8,11,17,21}-jre
 sudo update-alternatives --set java /usr/lib/jvm/temurin-21-jre-amd64/bin/java
-msg_ok "Installed TermurinJDK"
+msg_ok "Installed TemurinJDK"
 
 msg_info "Setup Python3"
 $STD apt-get install -y \
@@ -48,7 +43,6 @@ $STD apt-get install -y \
   python3-venv
 rm -rf /usr/lib/python3.*/EXTERNALLY-MANAGED
 msg_ok "Setup Python3"
-
 
 msg_info "Installing Craty-Controller (Patience)"
 useradd crafty -m -s /bin/bash
@@ -81,7 +75,7 @@ After=network.target
 Type=simple
 User=crafty
 WorkingDirectory=/opt/crafty-controller/crafty/crafty-4
-Environment=PATH=/opt/crafty-controller/crafty/.venv/bin:$PATH
+Environment=PATH=/usr/lib/jvm/temurin-21-jre-amd64/bin:/opt/crafty-controller/crafty/.venv/bin:$PATH
 ExecStart=/opt/crafty-controller/crafty/.venv/bin/python3 main.py -d
 Restart=on-failure
 


### PR DESCRIPTION
## ✍️ Description  
<!-- Provide a clear and concise description of your changes. -->  
This PR should finally fix an issue with crafty not correctly picking up the java path, as it runs within it's own user and own env.


## 🔗 Related PR / Discussion / Issue  
Link: #2237



## ✅ Prerequisites  
Before this PR can be reviewed, the following must be completed:  
- [x] **Self-review performed** – Code follows established patterns and conventions.  
- [x] **Testing performed** – Changes have been thoroughly tested and verified.  


## 🛠️ Type of Change  
Select all that apply:  
- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [] ✨ **New feature** – Adds new, non-breaking functionality.  
- [] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [] 🆕 **New script** – A fully functional and tested script or script set.  


## 📋 Additional Information (optional)  
<!-- Provide extra context, screenshots, or references if needed. -->  
